### PR TITLE
Remove .whitesource file

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,3 +1,0 @@
-{
-  "settingsInheritedFrom": "SmartBear/whitesource-config@main"
-}


### PR DESCRIPTION
Whitesource (renovate, mend.io) is not used anymore in the org. This PR removes the `.whitesource` file from the repository's root directory.